### PR TITLE
[TD-1] Normalize names and categorize tableframe functions and classes

### DIFF
--- a/client/td-lib/ta_interceptor/api/api.py
+++ b/client/td-lib/ta_interceptor/api/api.py
@@ -29,42 +29,42 @@ class InterceptorPlugin(ABC):
     @abstractmethod
     def standard_system_columns(self) -> list[str]:
         """
-        Returns a list of standard system TdLazyFrame columns.
+        Returns a list of standard system TableFrame columns.
         """
         pass
 
     @abstractmethod
     def extended_system_columns(self) -> list[str]:
         """
-        Returns a list of extended system TdLazyFrame columns.
+        Returns a list of extended system TableFrame columns.
         """
         pass
 
     @abstractmethod
     def system_columns(self) -> list[str]:
         """
-        Returns a list of system TdLazyFrame columns.
+        Returns a list of system TableFrame columns.
         """
         pass
 
     @abstractmethod
     def system_columns_metadata(self) -> dict[str, Any]:
         """
-        Returns a list of required system TdLazyFrame columns with their metadata.
+        Returns a list of required system TableFrame columns with their metadata.
         """
         pass
 
     @abstractmethod
     def required_columns(self) -> list[str]:
         """
-        Returns a list of required system TdLazyFrame columns.
+        Returns a list of required system TableFrame columns.
         """
         pass
 
     @abstractmethod
     def required_columns_metadata(self) -> dict[str, Any]:
         """
-        Returns a list of required system TdLazyFrame columns with their metadata.
+        Returns a list of required system TableFrame columns with their metadata.
         """
         pass
 

--- a/client/td-sdk/tabsdata/__init__.py
+++ b/client/td-sdk/tabsdata/__init__.py
@@ -44,11 +44,11 @@ from tabsdata.decorators import ALL_DEPS, publisher, subscriber, transformer
 from tabsdata.format import CSVFormat, LogFormat, NDJSONFormat, ParquetFormat
 from tabsdata.plugin import DestinationPlugin, SourcePlugin
 from tabsdata.secret import DirectSecret, EnvironmentSecret, HashiCorpSecret
-from tabsdata.tableframe.expr.expr import TdExpr as Expr
-from tabsdata.tableframe.functions.col import tdcol as col
+from tabsdata.tableframe.expr.expr import Expr as Expr
+from tabsdata.tableframe.functions.col import col as col
 from tabsdata.tableframe.functions.eager import concat
 from tabsdata.tableframe.functions.lit import lit
-from tabsdata.tableframe.lazyframe.frame import TdLazyFrame as TableFrame
+from tabsdata.tableframe.lazyframe.frame import LazyFrame as TableFrame
 from tabsdata.tableuri import TableURI
 from tabsdata.tabsdatafunction import (
     AzureDestination,
@@ -99,7 +99,7 @@ __all__ = [
     # from plugin.py
     "SourcePlugin",
     "DestinationPlugin",
-    # from decorators.py
+    # from pydoc.py
     "ALL_DEPS",
     "publisher",
     "subscriber",

--- a/client/td-sdk/tabsdata/decorators.py
+++ b/client/td-sdk/tabsdata/decorators.py
@@ -2,8 +2,8 @@
 # Copyright 2024 Tabs Data Inc.
 #
 
-
-from typing import List
+import logging
+from typing import List, ParamSpec, TypeVar
 
 from tabsdata.exceptions import DecoratorConfigurationError, ErrorCode
 from tabsdata.plugin import DestinationPlugin, SourcePlugin
@@ -27,7 +27,12 @@ from tabsdata.tabsdatafunction import (
     TabsdataFunction,
 )
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
 ALL_DEPS = "*"
+
+logger = logging.getLogger(__name__)
 
 
 def transformer(

--- a/client/td-sdk/tabsdata/exceptions.py
+++ b/client/td-sdk/tabsdata/exceptions.py
@@ -753,7 +753,7 @@ class ErrorCode(Enum):
     TF2 = {
         "code": "TF-002",
         "message": (
-            "TdTableFrame must be instantiated empty, or with a dictionary, or another"
+            "TableFrame must be instantiated empty, or with a dictionary, or another"
             " TableFrame. '{}' was provided instead."
         ),
     }
@@ -772,15 +772,15 @@ class ErrorCode(Enum):
     TF5 = {
         "code": "TF-005",
         "message": (
-            "Expr must be instantiated with a polars Expr or a TdExpr object: '{}' "
-            "was provided instead."
+            "Expr must be instantiated with a polars Expr or a Tabsdata Expr object:"
+            " '{}' was provided instead."
         ),
     }
     TF6 = {
         "code": "TF-006",
         "message": (
-            "GroupBy must be instantiated with a polars LazyGroupBY or a TdGroupBy "
-            "object: '{}' was provided instead."
+            "GroupBy must be instantiated with a polars LazyGroupBY or a Tabsdata"
+            " LazyGroupBy object: '{}' was provided instead."
         ),
     }
     TF7 = {
@@ -981,7 +981,7 @@ class SecretConfigurationError(TabsDataException):
 
 class TableFrameError(TabsDataException):
     """
-    Exception raised when handling a (Td)TableFrame.
+    Exception raised when handling a TableFrame.
     """
 
     CODE_PREFIX = "TF"

--- a/client/td-sdk/tabsdata/tableframe/_typing.py
+++ b/client/td-sdk/tabsdata/tableframe/_typing.py
@@ -4,6 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Mapping, Sequence, Union
+from typing import Mapping, Sequence, TypeAlias, Union
 
-TdDictionary = Mapping[str, Union[Sequence[object], Mapping[str, Sequence[object]]]]
+from polars import DataType
+from polars.datatypes import DataTypeClass
+
+TableDictionary = Mapping[str, Union[Sequence[object], Mapping[str, Sequence[object]]]]
+
+TdDataType: TypeAlias = Union["DataTypeClass", "DataType"]

--- a/client/td-sdk/tabsdata/tableframe/expr/expr.py
+++ b/client/td-sdk/tabsdata/tableframe/expr/expr.py
@@ -25,12 +25,13 @@ from polars._typing import (
     ClosedInterval,
     FillNullStrategy,
     NumericLiteral,
-    PolarsDataType,
     PythonLiteral,
     RankMethod,
     TemporalLiteral,
 )
 
+# noinspection PyProtectedMember
+import tabsdata.tableframe._typing as td_typing
 import tabsdata.tableframe.expr.string as td_string
 import tabsdata.tableframe.functions.datetime as td_datetime
 
@@ -40,17 +41,18 @@ import tabsdata.utils.tableframe._common as td_common
 # noinspection PyProtectedMember
 import tabsdata.utils.tableframe._translator as td_translator
 from tabsdata.exceptions import ErrorCode, TableFrameError
+from tabsdata.utils.annotations import pydoc
 
 T = TypeVar("T")
 P = ParamSpec("P")
 
 
 @accessify
-class TdExpr:
-    def __init__(self, expr: pl.Expr | TdExpr) -> None:
+class Expr:
+    def __init__(self, expr: pl.Expr | Expr) -> None:
         if isinstance(expr, pl.Expr):
             self._expr = expr
-        elif isinstance(expr, TdExpr):
+        elif isinstance(expr, Expr):
             self._expr = expr._expr
         else:
             raise TableFrameError(ErrorCode.TF5, type(expr))
@@ -66,123 +68,121 @@ class TdExpr:
     def __bool__(self) -> NoReturn:
         return self._expr.__bool__()
 
-    def __abs__(self) -> TdExpr:
-        return TdExpr(self._expr.__abs__())
+    def __abs__(self) -> Expr:
+        return Expr(self._expr.__abs__())
 
-    def __add__(self, other: IntoTdExpr) -> TdExpr:
+    def __add__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__add__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__add__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __radd__(self, other: IntoTdExpr) -> TdExpr:
+    def __radd__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__add__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__add__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __and__(self, other: IntoTdExprColumn | int | bool) -> TdExpr:
+    def __and__(self, other: IntoExprColumn | int | bool) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__and__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__and__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __rand__(self, other: IntoTdExprColumn | int | bool) -> TdExpr:
+    def __rand__(self, other: IntoExprColumn | int | bool) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__and__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__and__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __eq__(self, other: IntoTdExpr) -> TdExpr:  # type: ignore[override]
+    def __eq__(self, other: IntoExpr) -> Expr:  # type: ignore[override]
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__eq__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__eq__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __floordiv__(self, other: IntoTdExpr) -> TdExpr:
+    def __floordiv__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__floordiv__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__floordiv__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __rfloordiv__(self, other: IntoTdExpr) -> TdExpr:
+    def __rfloordiv__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(
-            self._expr.__rfloordiv__(td_translator._unwrap_into_tdexpr(other))
-        )
+        return Expr(self._expr.__rfloordiv__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __ge__(self, other: IntoTdExpr) -> TdExpr:
+    def __ge__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__ge__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__ge__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __gt__(self, other: IntoTdExpr) -> TdExpr:
+    def __gt__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__gt__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__gt__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __invert__(self) -> TdExpr:
-        return TdExpr(self._expr.__invert__())
+    def __invert__(self) -> Expr:
+        return Expr(self._expr.__invert__())
 
-    def __le__(self, other: IntoTdExpr) -> TdExpr:
+    def __le__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__le__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__le__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __lt__(self, other: IntoTdExpr) -> TdExpr:
+    def __lt__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__lt__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__lt__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __mod__(self, other: IntoTdExpr) -> TdExpr:
+    def __mod__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__mod__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__mod__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __rmod__(self, other: IntoTdExpr) -> TdExpr:
+    def __rmod__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__mod__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__mod__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __mul__(self, other: IntoTdExpr) -> TdExpr:
+    def __mul__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__mul__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__mul__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __rmul__(self, other: IntoTdExpr) -> TdExpr:
+    def __rmul__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__mul__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__mul__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __ne__(self, other: IntoTdExpr) -> TdExpr:  # type: ignore[override]
+    def __ne__(self, other: IntoExpr) -> Expr:  # type: ignore[override]
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__ne__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__ne__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __neg__(self) -> TdExpr:
-        return TdExpr(-self._expr)
+    def __neg__(self) -> Expr:
+        return Expr(-self._expr)
 
-    def __or__(self, other: IntoTdExprColumn | int | bool) -> TdExpr:
+    def __or__(self, other: IntoExprColumn | int | bool) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__or__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__or__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __ror__(self, other: IntoTdExprColumn | int | bool) -> TdExpr:
+    def __ror__(self, other: IntoExprColumn | int | bool) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__or__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__or__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __pos__(self) -> TdExpr:
-        return TdExpr(self._expr + self._expr)
+    def __pos__(self) -> Expr:
+        return Expr(self._expr + self._expr)
 
-    def __pow__(self, exponent: IntoTdExprColumn | int | float) -> TdExpr:
+    def __pow__(self, exponent: IntoExprColumn | int | float) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr ** td_translator._unwrap_into_tdexpr(exponent))
+        return Expr(self._expr ** td_translator._unwrap_into_tdexpr(exponent))
 
-    def __rpow__(self, base: IntoTdExprColumn | int | float) -> TdExpr:
+    def __rpow__(self, base: IntoExprColumn | int | float) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr ** td_translator._unwrap_into_tdexpr(base))
+        return Expr(self._expr ** td_translator._unwrap_into_tdexpr(base))
 
-    def __sub__(self, other: IntoTdExpr) -> TdExpr:
+    def __sub__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__sub__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__sub__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __rsub__(self, other: IntoTdExpr) -> TdExpr:
+    def __rsub__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__sub__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__sub__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __truediv__(self, other: IntoTdExpr) -> TdExpr:
+    def __truediv__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__truediv__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__truediv__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __rtruediv__(self, other: IntoTdExpr) -> TdExpr:
+    def __rtruediv__(self, other: IntoExpr) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__truediv__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__truediv__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __xor__(self, other: IntoTdExprColumn | int | bool) -> TdExpr:
+    def __xor__(self, other: IntoExprColumn | int | bool) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__xor__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__xor__(td_translator._unwrap_into_tdexpr(other)))
 
-    def __rxor__(self, other: IntoTdExprColumn | int | bool) -> TdExpr:
+    def __rxor__(self, other: IntoExprColumn | int | bool) -> Expr:
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.__xor__(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.__xor__(td_translator._unwrap_into_tdexpr(other)))
 
     def __getstate__(self) -> bytes:
         return self._expr.__getstate__()
@@ -192,13 +192,15 @@ class TdExpr:
 
     """ Object Operations """
 
-    def abs(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def abs(self) -> Expr:
         """
         Return the abso lute value of the expression.
         """
-        return TdExpr(self._expr.abs())
+        return Expr(self._expr.abs())
 
-    def add(self, other: Any) -> TdExpr:
+    @pydoc(categories="numeric")
+    def add(self, other: Any) -> Expr:
         """
         Equivalent to the `+` operator.
 
@@ -231,9 +233,10 @@ class TdExpr:
         └──────┴──────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.add(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.add(td_translator._unwrap_into_tdexpr(other)))
 
-    def alias(self, name: str) -> TdExpr:
+    @pydoc(categories="manipulation")
+    def alias(self, name: str) -> Expr:
         """
         Set the name for a column or expression.
 
@@ -265,9 +268,10 @@ class TdExpr:
         """
         # TODO: check name matches the regex in pydoc
         td_common.check_column(name)
-        return TdExpr(self._expr.alias(name))
+        return Expr(self._expr.alias(name))
 
-    def and_(self, *others: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def and_(self, *others: Any) -> Expr:
         """
         Bitwise `and` operator with the given expressions.
         It can be used with integer and bool types.
@@ -298,9 +302,10 @@ class TdExpr:
         └──────┴──────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.and_(td_translator._unwrap_into_tdexpr(*others)))
+        return Expr(self._expr.and_(td_translator._unwrap_into_tdexpr(*others)))
 
-    def arccos(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def arccos(self) -> Expr:
         """
         Calculate the inverse cosine of the element value.
 
@@ -326,9 +331,10 @@ class TdExpr:
         │ null ┆ null     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.arccos())
+        return Expr(self._expr.arccos())
 
-    def arccosh(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def arccosh(self) -> Expr:
         """
         Calculate the inverse hyperbolic cosine of the element value.
 
@@ -354,9 +360,10 @@ class TdExpr:
         │ null ┆ null     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.arccosh())
+        return Expr(self._expr.arccosh())
 
-    def arcsin(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def arcsin(self) -> Expr:
         """
         Calculate the inverse sine of the element value.
 
@@ -382,9 +389,10 @@ class TdExpr:
         │ null ┆ null     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.arcsin())
+        return Expr(self._expr.arcsin())
 
-    def arcsinh(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def arcsinh(self) -> Expr:
         """
         Calculate the inverse hyperbolic sine of the element value.
 
@@ -410,9 +418,10 @@ class TdExpr:
         │ null ┆ null     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.arcsinh())
+        return Expr(self._expr.arcsinh())
 
-    def arctan(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def arctan(self) -> Expr:
         """
         Calculate the inverse tangent of the element value.
 
@@ -438,9 +447,10 @@ class TdExpr:
         │ null ┆ null     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.arctan())
+        return Expr(self._expr.arctan())
 
-    def arctanh(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def arctanh(self) -> Expr:
         """
         Calculate the inverse hyperbolic tangent of the element value.
 
@@ -466,15 +476,16 @@ class TdExpr:
         │ null ┆ null     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.arctanh())
+        return Expr(self._expr.arctanh())
 
+    @pydoc(categories="type_casting")
     def cast(
         self,
-        dtype: PolarsDataType | type[Any],
+        dtype: td_typing.TdDataType | type[Any],
         *,
         strict: bool = True,
         wrap_numerical: bool = False,
-    ) -> TdExpr:
+    ) -> Expr:
         # noinspection PyShadowingNames
         """
         Cast a value to d different type.
@@ -509,11 +520,12 @@ class TdExpr:
         │ null ┆ null │
         └──────┴──────┘
         """
-        return TdExpr(
+        return Expr(
             self._expr.cast(dtype, strict=strict, wrap_numerical=wrap_numerical)
         )
 
-    def cbrt(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def cbrt(self) -> Expr:
         """
         Calculate the cub root of the element value.
 
@@ -539,9 +551,10 @@ class TdExpr:
         │ null ┆ null     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.cbrt())
+        return Expr(self._expr.cbrt())
 
-    def ceil(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def ceil(self) -> Expr:
         """
         Round up the expression to the next integer value.
 
@@ -562,13 +575,14 @@ class TdExpr:
         │ 1.1  ┆  2.0    │
         └──────┴─────────┘
         """
-        return TdExpr(self._expr.ceil())
+        return Expr(self._expr.ceil())
 
+    @pydoc(categories="numeric")
     def clip(
         self,
-        lower_bound: NumericLiteral | TemporalLiteral | IntoTdExprColumn | None = None,
-        upper_bound: NumericLiteral | TemporalLiteral | IntoTdExprColumn | None = None,
-    ) -> TdExpr:
+        lower_bound: NumericLiteral | TemporalLiteral | IntoExprColumn | None = None,
+        upper_bound: NumericLiteral | TemporalLiteral | IntoExprColumn | None = None,
+    ) -> Expr:
         """
         For element values outside the lower and upper bounds, lower values are
         replaced with the lower bound
@@ -600,14 +614,15 @@ class TdExpr:
         └──────┴─────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(
+        return Expr(
             self._expr.clip(
                 td_translator._unwrap_into_tdexpr_column(lower_bound),
                 td_translator._unwrap_into_tdexpr_column(upper_bound),
             )
         )
 
-    def cos(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def cos(self) -> Expr:
         """
         Calculate the cosine of the element value.
 
@@ -633,9 +648,10 @@ class TdExpr:
         │ null ┆ null      │
         └──────┴───────────┘
         """
-        return TdExpr(self._expr.cos())
+        return Expr(self._expr.cos())
 
-    def cosh(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def cosh(self) -> Expr:
         """
         Calculate the hyperbolic cosine of the element value.
 
@@ -661,9 +677,10 @@ class TdExpr:
         │ null ┆ null       │
         └──────┴────────────┘
         """
-        return TdExpr(self._expr.cosh())
+        return Expr(self._expr.cosh())
 
-    def cot(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def cot(self) -> Expr:
         """
         Calculate the cotangent of the element value.
 
@@ -689,9 +706,10 @@ class TdExpr:
         │ null ┆ null      │
         └──────┴───────────┘
         """
-        return TdExpr(self._expr.cot())
+        return Expr(self._expr.cot())
 
-    def degrees(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def degrees(self) -> Expr:
         """
         Convert a radian value to degrees
 
@@ -717,9 +735,10 @@ class TdExpr:
         │ null ┆ null       │
         └──────┴────────────┘
         """
-        return TdExpr(self._expr.degrees())
+        return Expr(self._expr.degrees())
 
-    def eq(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def eq(self, other: Any) -> Expr:
         """
         Compare if 2 expressions are equal, equivalent to `expr == other`. If one
         of the expressions is `null` (None) it returns `null`.
@@ -749,9 +768,10 @@ class TdExpr:
         └─────┴──────┴───────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.eq(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.eq(td_translator._unwrap_into_tdexpr(other)))
 
-    def eq_missing(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def eq_missing(self, other: Any) -> Expr:
         """
         Compare if 2 expressions are equal an, equivalent to `expr == other`. If one
         of the expressions is `null` (None) it returns `false`.
@@ -781,9 +801,10 @@ class TdExpr:
         └─────┴──────┴───────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.eq_missing(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.eq_missing(td_translator._unwrap_into_tdexpr(other)))
 
-    def exp(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def exp(self) -> Expr:
         """
         Calculate the exponential of the element value.
 
@@ -807,9 +828,10 @@ class TdExpr:
         │ null ┆ null        │
         └──────┴─────────────┘
         """
-        return TdExpr(self._expr.exp())
+        return Expr(self._expr.exp())
 
-    def fill_nan(self, value: int | float | TdExpr | None) -> TdExpr:
+    @pydoc(categories="manipulation")
+    def fill_nan(self, value: int | float | Expr | None) -> Expr:
         """
         Replace `NaN` values with the given value.
 
@@ -838,14 +860,15 @@ class TdExpr:
         └──────┴──────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.fill_nan(td_translator._unwrap_tdexpr(value)))
+        return Expr(self._expr.fill_nan(td_translator._unwrap_tdexpr(value)))
 
+    @pydoc(categories="manipulation")
     def fill_null(
         self,
-        value: Any | TdExpr | None = None,
+        value: Any | Expr | None = None,
         strategy: FillNullStrategy | None = None,
         limit: int | None = None,
-    ) -> TdExpr:
+    ) -> Expr:
         """
         Replace `null` values with the given value.
 
@@ -878,16 +901,17 @@ class TdExpr:
         └──────┴───────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(
+        return Expr(
             self._expr.fill_null(
                 td_translator._unwrap_into_tdexpr(value), strategy, limit
             )
         )
 
+    @pydoc(categories="filters")
     def filter(
         self,
-        *predicates: IntoTdExprColumn | Iterable[IntoTdExprColumn],
-    ) -> TdExpr:
+        *predicates: IntoExprColumn | Iterable[IntoExprColumn],
+    ) -> Expr:
         """
         Apply a filter predicate to an expression.
 
@@ -933,11 +957,12 @@ class TdExpr:
         └───────┴─────────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(
+        return Expr(
             self._expr.filter(td_translator._unwrap_into_tdexpr_column(*predicates))
         )
 
-    def first(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def first(self) -> Expr:
         """
         Get the first element.
 
@@ -961,9 +986,10 @@ class TdExpr:
         │ 70   ┆ 10      │
         └──────┴─────────┘
         """
-        return TdExpr(self._expr.first())
+        return Expr(self._expr.first())
 
-    def floor(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def floor(self) -> Expr:
         """
         Round down the expression to the previous integer value.
 
@@ -984,9 +1010,9 @@ class TdExpr:
         │ 1.1  ┆  1      │
         └──────┴─────────┘
         """
-        return TdExpr(self._expr.floor())
+        return Expr(self._expr.floor())
 
-    def floordiv(self, other: Any) -> TdExpr:
+    def floordiv(self, other: Any) -> Expr:
         """
         Calculate the floor on the division.
 
@@ -1012,9 +1038,10 @@ class TdExpr:
         └──────┴──────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.floordiv(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.floordiv(td_translator._unwrap_into_tdexpr(other)))
 
-    def ge(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def ge(self, other: Any) -> Expr:
         """
         Greater or equal operator.
 
@@ -1039,9 +1066,10 @@ class TdExpr:
         └──────┴─────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.ge(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.ge(td_translator._unwrap_into_tdexpr(other)))
 
-    def gt(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def gt(self, other: Any) -> Expr:
         """
         Greater than operator.
 
@@ -1066,15 +1094,16 @@ class TdExpr:
         └──────┴─────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.gt(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.gt(td_translator._unwrap_into_tdexpr(other)))
 
+    @pydoc(categories="numeric")
     def hash(
         self,
         seed: int = 0,
         seed_1: int | None = None,
         seed_2: int | None = None,
         seed_3: int | None = None,
-    ) -> TdExpr:
+    ) -> Expr:
         """
         Compute the hash of an element value.
 
@@ -1101,14 +1130,15 @@ class TdExpr:
         │ 2.0  ┆ 4738789230185236462 │
         └──────┴─────────────────────┘
         """
-        return TdExpr(self._expr.hash(seed, seed_1, seed_2, seed_3))
+        return Expr(self._expr.hash(seed, seed_1, seed_2, seed_3))
 
+    @pydoc(categories="logic")
     def is_between(
         self,
-        lower_bound: IntoTdExpr,
-        upper_bound: IntoTdExpr,
+        lower_bound: IntoExpr,
+        upper_bound: IntoExpr,
         closed: ClosedInterval = "both",
-    ) -> TdExpr:
+    ) -> Expr:
         """
         If an expression is between the given bounds.
 
@@ -1139,7 +1169,7 @@ class TdExpr:
         └──────┴─────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(
+        return Expr(
             self._expr.is_between(
                 td_translator._unwrap_into_tdexpr(lower_bound),
                 td_translator._unwrap_into_tdexpr(upper_bound),
@@ -1147,7 +1177,8 @@ class TdExpr:
             )
         )
 
-    def is_finite(self) -> TdExpr:
+    @pydoc(categories="logic")
+    def is_finite(self) -> Expr:
         """
         If an element value is finite.
 
@@ -1170,9 +1201,10 @@ class TdExpr:
         │ inf  ┆ false  │
         └──────┴────────┘
         """
-        return TdExpr(self._expr.is_finite())
+        return Expr(self._expr.is_finite())
 
-    def is_in(self, other: TdExpr | Collection[Any] | Series) -> TdExpr:
+    @pydoc(categories="logic")
+    def is_in(self, other: Expr | Collection[Any] | Series) -> Expr:
         """
         If an element value is in the given collection.
 
@@ -1199,9 +1231,10 @@ class TdExpr:
         └──────┴────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.is_in(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.is_in(td_translator._unwrap_into_tdexpr(other)))
 
-    def is_infinite(self) -> TdExpr:
+    @pydoc(categories="logic")
+    def is_infinite(self) -> Expr:
         """
         If an element value is infinite.
 
@@ -1224,9 +1257,10 @@ class TdExpr:
         │ inf  ┆ true     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.is_infinite())
+        return Expr(self._expr.is_infinite())
 
-    def is_nan(self) -> TdExpr:
+    @pydoc(categories="logic")
+    def is_nan(self) -> Expr:
         """
         If an element value is `NaN`.
 
@@ -1249,9 +1283,10 @@ class TdExpr:
         │ inf  ┆ false    │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.is_nan())
+        return Expr(self._expr.is_nan())
 
-    def is_not_nan(self) -> TdExpr:
+    @pydoc(categories="logic")
+    def is_not_nan(self) -> Expr:
         """
         If an element value is not `NaN`.
 
@@ -1275,9 +1310,10 @@ class TdExpr:
         │ inf  ┆ true     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.is_not_nan())
+        return Expr(self._expr.is_not_nan())
 
-    def is_not_null(self) -> TdExpr:
+    @pydoc(categories="logic")
+    def is_not_null(self) -> Expr:
         """
         If an element value is not `null` (None).
 
@@ -1301,9 +1337,10 @@ class TdExpr:
         │ inf  ┆ true     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.is_not_null())
+        return Expr(self._expr.is_not_null())
 
-    def is_null(self) -> TdExpr:
+    @pydoc(categories="logic")
+    def is_null(self) -> Expr:
         """
         If an element value is `null` (None).
 
@@ -1327,9 +1364,10 @@ class TdExpr:
         │ inf  ┆ false    │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.is_null())
+        return Expr(self._expr.is_null())
 
-    def is_unique(self) -> TdExpr:
+    @pydoc(categories="logic")
+    def is_unique(self) -> Expr:
         """
         If an element value is unique for all values in the column.
 
@@ -1353,9 +1391,10 @@ class TdExpr:
         │ 2.0  ┆ true     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.is_unique())
+        return Expr(self._expr.is_unique())
 
-    def last(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def last(self) -> Expr:
         """
         Get the last element.
 
@@ -1379,9 +1418,10 @@ class TdExpr:
         │ 70   ┆ 70      │
         └──────┴─────────┘
         """
-        return TdExpr(self._expr.last())
+        return Expr(self._expr.last())
 
-    def le(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def le(self, other: Any) -> Expr:
         """
         Less or equal operator.
 
@@ -1406,9 +1446,10 @@ class TdExpr:
         └──────┴─────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.le(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.le(td_translator._unwrap_into_tdexpr(other)))
 
-    def log(self, base: float = math.e) -> TdExpr:
+    @pydoc(categories="numeric")
+    def log(self, base: float = math.e) -> Expr:
         """
         Calculate the logarithm to the given base.
 
@@ -1437,9 +1478,10 @@ class TdExpr:
         │ NaN  ┆ NaN      │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.log(base))
+        return Expr(self._expr.log(base))
 
-    def log1p(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def log1p(self) -> Expr:
         """
         Calculate the natural logarithm plus one.
 
@@ -1465,9 +1507,10 @@ class TdExpr:
         │ NaN  ┆ NaN      │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.log1p())
+        return Expr(self._expr.log1p())
 
-    def log10(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def log10(self) -> Expr:
         """
         Calculate the logarithm base 10.
 
@@ -1493,9 +1536,10 @@ class TdExpr:
         │ NaN  ┆ NaN      │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.log10())
+        return Expr(self._expr.log10())
 
-    def lt(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def lt(self, other: Any) -> Expr:
         """
         Less than operator.
 
@@ -1520,9 +1564,10 @@ class TdExpr:
         └──────┴─────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.lt(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.lt(td_translator._unwrap_into_tdexpr(other)))
 
-    def mod(self, other: Any) -> TdExpr:
+    @pydoc(categories="numeric")
+    def mod(self, other: Any) -> Expr:
         """
         Modulus operator.
 
@@ -1549,9 +1594,10 @@ class TdExpr:
         └──────┴──────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.mod(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.mod(td_translator._unwrap_into_tdexpr(other)))
 
-    def mul(self, other: Any) -> TdExpr:
+    @pydoc(categories="numeric")
+    def mul(self, other: Any) -> Expr:
         """
         Multiplication operator.
 
@@ -1579,9 +1625,10 @@ class TdExpr:
         └──────┴──────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.mul(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.mul(td_translator._unwrap_into_tdexpr(other)))
 
-    def ne(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def ne(self, other: Any) -> Expr:
         """
         Compare if 2 expressions are not equal, equivalent to `expr != other`. If one
         of the expressions is `null` (None) it returns `null`.
@@ -1611,9 +1658,10 @@ class TdExpr:
         └─────┴──────┴───────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.ne(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.ne(td_translator._unwrap_into_tdexpr(other)))
 
-    def ne_missing(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def ne_missing(self, other: Any) -> Expr:
         """
         Compare if 2 expressions are not equal an, equivalent to `expr != other`. If one
         of the expressions is `null` (None) it returns `false`.
@@ -1643,9 +1691,10 @@ class TdExpr:
         └─────┴──────┴───────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.ne_missing(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.ne_missing(td_translator._unwrap_into_tdexpr(other)))
 
-    def neg(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def neg(self) -> Expr:
         """
         Unary minus operator.
 
@@ -1671,9 +1720,10 @@ class TdExpr:
         │ NaN  ┆ NaN  │
         └──────┴──────┘
         """
-        return TdExpr(self._expr.neg())
+        return Expr(self._expr.neg())
 
-    def not_(self) -> TdExpr:
+    @pydoc(categories="logic")
+    def not_(self) -> Expr:
         """
         Negate a boolean expression.
 
@@ -1695,9 +1745,10 @@ class TdExpr:
         │ null  ┆ null  │
         └───────┴───────┘
         """
-        return TdExpr(self._expr.not_())
+        return Expr(self._expr.not_())
 
-    def or_(self, *others: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def or_(self, *others: Any) -> Expr:
         """
         Bitwise `or` operator with the given expressions.
         It can be used with integer and bool types.
@@ -1726,9 +1777,10 @@ class TdExpr:
         └──────┴──────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.or_(td_translator._unwrap_into_tdexpr(*others)))
+        return Expr(self._expr.or_(td_translator._unwrap_into_tdexpr(*others)))
 
-    def pow(self, exponent: IntoTdExprColumn | int | float) -> TdExpr:
+    @pydoc(categories="numeric")
+    def pow(self, exponent: IntoExprColumn | int | float) -> Expr:
         """
         Exponentiation operator.
 
@@ -1756,11 +1808,10 @@ class TdExpr:
         └──────┴──────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(
-            self._expr.pow(td_translator._unwrap_into_tdexpr_column(exponent))
-        )
+        return Expr(self._expr.pow(td_translator._unwrap_into_tdexpr_column(exponent)))
 
-    def radians(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def radians(self) -> Expr:
         """
         Convert a degree value to radians
 
@@ -1784,15 +1835,16 @@ class TdExpr:
         │ null    ┆ null     │
         └─────────┴──────────┘
         """
-        return TdExpr(self._expr.radians())
+        return Expr(self._expr.radians())
 
+    @pydoc(categories="aggregation")
     def rank(
         self,
         method: RankMethod = "average",
         *,
         descending: bool = False,
         seed: int | None = None,
-    ) -> TdExpr:
+    ) -> Expr:
         """
         Compute the rank of the element values. Multiple rank types are available.
 
@@ -1824,9 +1876,10 @@ class TdExpr:
         │ NaN  ┆ 6    │
         └──────┴──────┘
         """
-        return TdExpr(self._expr.rank(method=method, descending=descending, seed=seed))
+        return Expr(self._expr.rank(method=method, descending=descending, seed=seed))
 
-    def diff(self, n: int = 1) -> TdExpr:
+    @pydoc(categories="numeric")
+    def diff(self, n: int = 1) -> Expr:
         """
         Compute the difference between an element value and the element value
         of the specified relative row.
@@ -1865,9 +1918,10 @@ class TdExpr:
         """
         # Dropping 'null_behavior' as it is breaks when more than one column (we have
         # system columns)
-        return TdExpr(self._expr.diff(n))
+        return Expr(self._expr.diff(n))
 
-    def reinterpret(self, *, signed: bool = True) -> TdExpr:
+    @pydoc(categories="numeric")
+    def reinterpret(self, *, signed: bool = True) -> Expr:
         """
         Reinterpret the 64bit element values (i64 or u64) as a signed/unsigned integers.
         Only valid for 64bit integers, for other types use cast.
@@ -1899,9 +1953,10 @@ class TdExpr:
         │ null ┆ null        │
         └──────┴─────────────┘
         """
-        return TdExpr(self._expr.reinterpret(signed=signed))
+        return Expr(self._expr.reinterpret(signed=signed))
 
-    def round(self, decimals: int = 0) -> TdExpr:
+    @pydoc(categories="numeric")
+    def round(self, decimals: int = 0) -> Expr:
         """
         Round floating point element values.
 
@@ -1930,9 +1985,10 @@ class TdExpr:
         │ NaN  ┆ NaN   │
         └──────┴───────┘
         """
-        return TdExpr(self._expr.round(decimals))
+        return Expr(self._expr.round(decimals))
 
-    def round_sig_figs(self, digits: int) -> TdExpr:
+    @pydoc(categories="numeric")
+    def round_sig_figs(self, digits: int) -> Expr:
         """
         Round floating point element values to the specified significant figures.
 
@@ -1965,9 +2021,10 @@ class TdExpr:
         │ 2142.0 ┆ 2100.0         │
         └────────┴────────────────┘
         """
-        return TdExpr(self._expr.round_sig_figs(digits))
+        return Expr(self._expr.round_sig_figs(digits))
 
-    def shrink_dtype(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def shrink_dtype(self) -> Expr:
         """
         Cast down a column to the smallest type that can hold the element values.
 
@@ -1990,9 +2047,10 @@ class TdExpr:
         │ 65025 ┆ 65025        │
         └───────┴──────────────┘
         """
-        return TdExpr(self._expr.shrink_dtype())
+        return Expr(self._expr.shrink_dtype())
 
-    def sign(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def sign(self) -> Expr:
         """
         Calculate the sign of element values.
 
@@ -2021,9 +2079,10 @@ class TdExpr:
         │ 2142.0 ┆ 1.0  │
         └────────┴──────┘
         """
-        return TdExpr(self._expr.sign())
+        return Expr(self._expr.sign())
 
-    def sin(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def sin(self) -> Expr:
         """
         Calculate the sine of the element value.
 
@@ -2047,9 +2106,10 @@ class TdExpr:
         └─────┴───────────┘
 
         """
-        return TdExpr(self._expr.sin())
+        return Expr(self._expr.sin())
 
-    def sinh(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def sinh(self) -> Expr:
         """
         Calculate the hyperbolic sine of the element value.
 
@@ -2072,9 +2132,10 @@ class TdExpr:
         │ 90  ┆ 6.1020e38 │
         └─────┴───────────┘
         """
-        return TdExpr(self._expr.sinh())
+        return Expr(self._expr.sinh())
 
-    def count(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def count(self) -> Expr:
         """
         Aggregation operation that counts the non `null` values of the given column in
         the group.
@@ -2112,9 +2173,10 @@ class TdExpr:
         │ C    ┆ 1     │
         └──────┴───────┘
         """
-        return TdExpr(self._expr.count())
+        return Expr(self._expr.count())
 
-    def len(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def len(self) -> Expr:
         """
         Aggregation operation that counts the rows in the group.
 
@@ -2151,9 +2213,10 @@ class TdExpr:
         │ C    ┆ 2   │
         └──────┴─────┘
         """
-        return TdExpr(self._expr.len())
+        return Expr(self._expr.len())
 
-    def slice(self, offset: int | TdExpr, length: int | TdExpr | None = None) -> TdExpr:
+    @pydoc(categories="filters")
+    def slice(self, offset: int | Expr, length: int | Expr | None = None) -> Expr:
         """
         Compute a slice of the `TableFrame` for the specified columns.
 
@@ -2192,14 +2255,15 @@ class TdExpr:
         └─────┴─────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(
+        return Expr(
             self._expr.slice(
                 td_translator._unwrap_tdexpr(offset),
                 td_translator._unwrap_tdexpr(length),
             )
         )
 
-    def sqrt(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def sqrt(self) -> Expr:
         """
         Calculate the square root of the element value.
 
@@ -2224,9 +2288,10 @@ class TdExpr:
         │ null ┆ null     │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.sqrt())
+        return Expr(self._expr.sqrt())
 
-    def sub(self, other: Any) -> TdExpr:
+    @pydoc(categories="numeric")
+    def sub(self, other: Any) -> Expr:
         """
         Equivalent to the `-` operator.
 
@@ -2256,9 +2321,10 @@ class TdExpr:
         └──────┴──────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.sub(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.sub(td_translator._unwrap_into_tdexpr(other)))
 
-    def max(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def max(self) -> Expr:
         """
         Aggregation operation that finds the maximum value in the group.
 
@@ -2301,9 +2367,10 @@ class TdExpr:
         │ null ┆ null │
         └──────┴──────┘
         """
-        return TdExpr(self._expr.max())
+        return Expr(self._expr.max())
 
-    def min(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def min(self) -> Expr:
         """
         Aggregation operation that finds the minimum value in the group.
 
@@ -2346,9 +2413,10 @@ class TdExpr:
         │ D    ┆ -4   │
         └──────┴──────┘
         """
-        return TdExpr(self._expr.min())
+        return Expr(self._expr.min())
 
-    def sum(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def sum(self) -> Expr:
         """
         Aggregation operation that sums the values in the group.
 
@@ -2391,9 +2459,10 @@ class TdExpr:
         │ F    ┆ -5  │
         └──────┴─────┘
         """
-        return TdExpr(self._expr.sum())
+        return Expr(self._expr.sum())
 
-    def mean(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def mean(self) -> Expr:
         """
         Aggregation operation that finds the mean of the values in the group.
 
@@ -2436,9 +2505,10 @@ class TdExpr:
         │ B    ┆ 2.333333 │
         └──────┴──────────┘
         """
-        return TdExpr(self._expr.mean())
+        return Expr(self._expr.mean())
 
-    def median(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def median(self) -> Expr:
         """
         Aggregation operation that finds the median of the values in the group.
 
@@ -2481,9 +2551,10 @@ class TdExpr:
         │ null ┆ null │
         └──────┴──────┘
         """
-        return TdExpr(self._expr.median())
+        return Expr(self._expr.median())
 
-    def n_unique(self) -> TdExpr:
+    @pydoc(categories="aggregation")
+    def n_unique(self) -> Expr:
         """
         Aggregation operation that counts the unique values of the given column
         in the group.
@@ -2527,9 +2598,10 @@ class TdExpr:
         │ null ┆ 1   │
         └──────┴─────┘
         """
-        return TdExpr(self._expr.n_unique())
+        return Expr(self._expr.n_unique())
 
-    def tan(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def tan(self) -> Expr:
         """
         Calculate the tangent of the element value.
 
@@ -2552,9 +2624,10 @@ class TdExpr:
         │ 90  ┆ -1.9952   │
         └─────┴───────────┘
         """
-        return TdExpr(self._expr.tan())
+        return Expr(self._expr.tan())
 
-    def tanh(self) -> TdExpr:
+    @pydoc(categories="numeric")
+    def tanh(self) -> Expr:
         """
         Calculate the hyperbolic tangent of the element value.
 
@@ -2577,9 +2650,10 @@ class TdExpr:
         │ 9.0 ┆ 1.0      │
         └─────┴──────────┘
         """
-        return TdExpr(self._expr.tanh())
+        return Expr(self._expr.tanh())
 
-    def truediv(self, other: Any) -> TdExpr:
+    @pydoc(categories="numeric")
+    def truediv(self, other: Any) -> Expr:
         """
         Equivalent to the float `/` operator.
 
@@ -2612,9 +2686,10 @@ class TdExpr:
         └────────┴────────────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.truediv(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.truediv(td_translator._unwrap_into_tdexpr(other)))
 
-    def xor(self, other: Any) -> TdExpr:
+    @pydoc(categories="logic")
+    def xor(self, other: Any) -> Expr:
         """
         Bitwise `xor` operator with the given expression.
         It can be used with integer and bool types.
@@ -2642,25 +2717,27 @@ class TdExpr:
         └─────┴─────┘
         """
         # noinspection PyProtectedMember
-        return TdExpr(self._expr.xor(td_translator._unwrap_into_tdexpr(other)))
+        return Expr(self._expr.xor(td_translator._unwrap_into_tdexpr(other)))
 
     """ Object Properties"""
 
+    @pydoc(categories="type_casting")
     @property
-    def dt(self) -> td_datetime.TdExprDateTimeNameSpace:
+    def dt(self) -> td_datetime.ExprDateTimeNameSpace:
         """
         Return an object namespace with all date-time methods for a date-time value.
         """
-        return td_datetime.TdExprDateTimeNameSpace(self._expr.dt)
+        return td_datetime.ExprDateTimeNameSpace(self._expr.dt)
 
+    @pydoc(categories="type_casting")
     @property
-    def str(self) -> td_string.TdExprStringNameSpace:
+    def str(self) -> td_string.ExprStringNameSpace:
         """
         Return an object namespace with all string methods for a string value.
         """
-        return td_string.TdExprStringNameSpace(self._expr.str)
+        return td_string.ExprStringNameSpace(self._expr.str)
 
 
-IntoTdExprColumn: TypeAlias = Union[TdExpr, pl.Series, str]
+IntoExprColumn: TypeAlias = Union[Expr, pl.Series, str]
 
-IntoTdExpr: TypeAlias = Union[PythonLiteral, IntoTdExprColumn, None]
+IntoExpr: TypeAlias = Union[PythonLiteral, IntoExprColumn, None]

--- a/client/td-sdk/tabsdata/tableframe/expr/string.py
+++ b/client/td-sdk/tabsdata/tableframe/expr/string.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+import polars.expr.string as pl_string
 from polars import Expr
 
 # noinspection PyProtectedMember
@@ -13,29 +14,31 @@ from polars._typing import Ambiguous, TimeUnit
 
 # noinspection PyProtectedMember
 from polars._utils.various import NoDefault, no_default
-from polars.expr.string import ExprStringNameSpace
 
 import tabsdata.tableframe.expr.expr as td_expr
 
 # noinspection PyProtectedMember
 import tabsdata.utils.tableframe._translator as td_translator
+from tabsdata.utils.annotations import pydoc
 
 
-def to_tdexpr(expr: Expr) -> td_expr.TdExpr:
-    return td_expr.TdExpr(expr)
+# ToDo: This requires some refactoring to unify transformer methods
+def _to_tdexpr(expr: Expr) -> td_expr.Expr:
+    return td_expr.Expr(expr)
 
 
-class TdExprStringNameSpace:
-    def __init__(self, expr: ExprStringNameSpace) -> None:
+class ExprStringNameSpace:
+    def __init__(self, expr: pl_string.ExprStringNameSpace) -> None:
         # noinspection PyProtectedMember
         self._expr = expr
 
+    @pydoc(categories="type_casting")
     def to_date(
         self,
         fmt: str | None = None,
         *,
         strict: bool = True,
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         """
         Convert the string to a date.
 
@@ -62,10 +65,11 @@ class TdExprStringNameSpace:
         │ null       ┆ null       │
         └────────────┴────────────┘
         """
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.to_date(format=fmt, strict=strict, exact=True, cache=True)
         )
 
+    @pydoc(categories="type_casting")
     def to_datetime(
         self,
         fmt: str | None = None,
@@ -73,8 +77,8 @@ class TdExprStringNameSpace:
         time_unit: TimeUnit | None = None,
         time_zone: str | None = None,
         strict: bool = True,
-        ambiguous: Ambiguous | td_expr.TdExpr = "raise",
-    ) -> td_expr.TdExpr:
+        ambiguous: Ambiguous | td_expr.Expr = "raise",
+    ) -> td_expr.Expr:
         """
         Convert the string to a datetime.
 
@@ -109,7 +113,7 @@ class TdExprStringNameSpace:
         └─────────────────────┴─────────────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.to_datetime(
                 format=fmt,
                 time_unit=time_unit,
@@ -121,9 +125,10 @@ class TdExprStringNameSpace:
             )
         )
 
+    @pydoc(categories="type_casting")
     def to_time(
         self, fmt: str | None = None, *, strict: bool = True, cache: bool = True
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         """
         Convert the string to a time.
 
@@ -151,9 +156,10 @@ class TdExprStringNameSpace:
         │ null                ┆ null                │
         └─────────────────────┴─────────────────────┘
         """
-        return to_tdexpr(self._expr.to_time(format=fmt, strict=strict, cache=cache))
+        return _to_tdexpr(self._expr.to_time(format=fmt, strict=strict, cache=cache))
 
-    def len_bytes(self) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def len_bytes(self) -> td_expr.Expr:
         """
         Return number of bytes (not chars) of a string.
 
@@ -175,9 +181,10 @@ class TdExprStringNameSpace:
         │ null ┆ null       │
         └──────┴────────────┘
         """
-        return to_tdexpr(self._expr.len_bytes())
+        return _to_tdexpr(self._expr.len_bytes())
 
-    def len_chars(self) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def len_chars(self) -> td_expr.Expr:
         """
         Return number of chars (not bytes) of a string.
 
@@ -199,9 +206,10 @@ class TdExprStringNameSpace:
         │ null ┆ null       │
         └──────┴────────────┘
         """
-        return to_tdexpr(self._expr.len_chars())
+        return _to_tdexpr(self._expr.len_chars())
 
-    def to_uppercase(self) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def to_uppercase(self) -> td_expr.Expr:
         """
         Return the uppercase of a string.
 
@@ -222,9 +230,10 @@ class TdExprStringNameSpace:
         │ null ┆ null         │
         └──────┴──────────────┘
         """
-        return to_tdexpr(self._expr.to_uppercase())
+        return _to_tdexpr(self._expr.to_uppercase())
 
-    def to_lowercase(self) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def to_lowercase(self) -> td_expr.Expr:
         """
         Return the lowercase of a string.
 
@@ -245,9 +254,10 @@ class TdExprStringNameSpace:
         │ null ┆ null          │
         └──────┴───────────────┘
         """
-        return to_tdexpr(self._expr.to_lowercase())
+        return _to_tdexpr(self._expr.to_lowercase())
 
-    def to_titlecase(self) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def to_titlecase(self) -> td_expr.Expr:
         """
         Uppercase the first character and lowercase all the others ones of a string.
 
@@ -271,9 +281,10 @@ class TdExprStringNameSpace:
         │ null ┆ null      │
         └──────┴───────────┘
         """
-        return to_tdexpr(self._expr.to_titlecase())
+        return _to_tdexpr(self._expr.to_titlecase())
 
-    def strip_chars(self, characters: td_expr.IntoTdExpr = None) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def strip_chars(self, characters: td_expr.IntoExpr = None) -> td_expr.Expr:
         """
         Trim string values.
 
@@ -302,15 +313,14 @@ class TdExprStringNameSpace:
         └─────────────────────────────────┴─────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.strip_chars(
                 characters=td_translator._unwrap_into_tdexpr(characters)
             )
         )
 
-    def strip_chars_start(
-        self, characters: td_expr.IntoTdExpr = None
-    ) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def strip_chars_start(self, characters: td_expr.IntoExpr = None) -> td_expr.Expr:
         """
         Trim string values from the start of the string.
 
@@ -339,13 +349,14 @@ class TdExprStringNameSpace:
         └───────────────────────────────┴────────────────────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.strip_chars_start(
                 characters=td_translator._unwrap_into_tdexpr(characters)
             )
         )
 
-    def strip_chars_end(self, characters: td_expr.IntoTdExpr = None) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def strip_chars_end(self, characters: td_expr.IntoExpr = None) -> td_expr.Expr:
         """
         Trim string values from the end of the string.
 
@@ -374,13 +385,14 @@ class TdExprStringNameSpace:
         └───────────────────────────────┴─────────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.strip_chars_end(
                 characters=td_translator._unwrap_into_tdexpr(characters)
             )
         )
 
-    def strip_prefix(self, prefix: td_expr.IntoTdExpr) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def strip_prefix(self, prefix: td_expr.IntoExpr) -> td_expr.Expr:
         """
         Trim string values removing the given prefix
 
@@ -406,9 +418,10 @@ class TdExprStringNameSpace:
         │ null                          ┆ null            │
         └───────────────────────────────┴─────────────────┘
         """
-        return to_tdexpr(self._expr.strip_prefix(prefix=prefix))
+        return _to_tdexpr(self._expr.strip_prefix(prefix=prefix))
 
-    def strip_suffix(self, suffix: td_expr.IntoTdExpr) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def strip_suffix(self, suffix: td_expr.IntoExpr) -> td_expr.Expr:
         """
         Trim string values removing the given suffix
 
@@ -434,9 +447,10 @@ class TdExprStringNameSpace:
         │ null                          ┆ null            │
         └───────────────────────────────┴─────────────────┘
         """
-        return to_tdexpr(self._expr.strip_suffix(suffix=suffix))
+        return _to_tdexpr(self._expr.strip_suffix(suffix=suffix))
 
-    def pad_start(self, length: int, fill_char: str = " ") -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def pad_start(self, length: int, fill_char: str = " ") -> td_expr.Expr:
         """
         Pad string values at the front to the given length using the given
         fill character.
@@ -463,9 +477,10 @@ class TdExprStringNameSpace:
         │ null   ┆ null      │
         └────────┴───────────┘
         """
-        return to_tdexpr(self._expr.pad_start(length=length, fill_char=fill_char))
+        return _to_tdexpr(self._expr.pad_start(length=length, fill_char=fill_char))
 
-    def pad_end(self, length: int, fill_char: str = " ") -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def pad_end(self, length: int, fill_char: str = " ") -> td_expr.Expr:
         """
         Pad string values at the end to the given length using the given
         fill character.
@@ -492,9 +507,10 @@ class TdExprStringNameSpace:
         │ null   ┆ null    │
         └────────┴─────────┘
         """
-        return to_tdexpr(self._expr.pad_end(length=length, fill_char=fill_char))
+        return _to_tdexpr(self._expr.pad_end(length=length, fill_char=fill_char))
 
-    def zfill(self, length: int | td_expr.IntoTdExprColumn) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def zfill(self, length: int | td_expr.IntoExprColumn) -> td_expr.Expr:
         """
         Pad numeric string values at the start to the given length using zeros.
 
@@ -520,15 +536,16 @@ class TdExprStringNameSpace:
         │ null ┆ null  │
         └──────┴───────┘
         """
-        return to_tdexpr(self._expr.zfill(length=length))
+        return _to_tdexpr(self._expr.zfill(length=length))
 
+    @pydoc(categories="string")
     def contains(
         self,
-        pattern: str | td_expr.TdExpr,
+        pattern: str | td_expr.Expr,
         *,
         literal: bool = False,
         strict: bool = True,
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         """
         Evaluate if the string contains a pattern.
 
@@ -557,7 +574,7 @@ class TdExprStringNameSpace:
         └──────┴──────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.contains(
                 pattern=td_expr.td_translator._unwrap_tdexpr(pattern),
                 literal=literal,
@@ -565,13 +582,14 @@ class TdExprStringNameSpace:
             )
         )
 
+    @pydoc(categories="string")
     def find(
         self,
-        pattern: str | td_expr.TdExpr,
+        pattern: str | td_expr.Expr,
         *,
         literal: bool = False,
         strict: bool = True,
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         """
         Find the position of the first occurrence of the given pattern.
 
@@ -600,7 +618,7 @@ class TdExprStringNameSpace:
         └──────┴──────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.find(
                 pattern=td_expr.td_translator._unwrap_tdexpr(pattern),
                 literal=literal,
@@ -608,7 +626,8 @@ class TdExprStringNameSpace:
             )
         )
 
-    def ends_with(self, suffix: str | td_expr.TdExpr) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def ends_with(self, suffix: str | td_expr.Expr) -> td_expr.Expr:
         """
         Evaluate if the string ends with.
 
@@ -635,11 +654,12 @@ class TdExprStringNameSpace:
         └──────┴───────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.ends_with(suffix=td_expr.td_translator._unwrap_tdexpr(suffix))
         )
 
-    def starts_with(self, prefix: str | td_expr.TdExpr) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def starts_with(self, prefix: str | td_expr.Expr) -> td_expr.Expr:
         """
         Evaluate if the string start with.
 
@@ -667,13 +687,14 @@ class TdExprStringNameSpace:
         └──────┴────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.starts_with(prefix=td_expr.td_translator._unwrap_tdexpr(prefix))
         )
 
+    @pydoc(categories="string")
     def extract(
-        self, pattern: td_expr.IntoTdExprColumn, group_index: int = 1
-    ) -> td_expr.TdExpr:
+        self, pattern: td_expr.IntoExprColumn, group_index: int = 1
+    ) -> td_expr.Expr:
         """
         Extract a pattern from the string.
 
@@ -701,16 +722,17 @@ class TdExprStringNameSpace:
         └───────────┴─────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.extract(
                 pattern=td_translator._unwrap_into_tdexpr_column(pattern),
                 group_index=group_index,
             )
         )
 
+    @pydoc(categories="string")
     def count_matches(
-        self, pattern: str | td_expr.TdExpr, *, literal: bool = False
-    ) -> td_expr.TdExpr:
+        self, pattern: str | td_expr.Expr, *, literal: bool = False
+    ) -> td_expr.Expr:
         """
         Counts the ocurrrences of the given pattern in the string.
 
@@ -741,20 +763,21 @@ class TdExprStringNameSpace:
         └───────────┴───────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.count_matches(
                 pattern=td_expr.td_translator._unwrap_tdexpr(pattern), literal=literal
             )
         )
 
+    @pydoc(categories="string")
     def replace(
         self,
-        pattern: str | td_expr.TdExpr,
-        value: str | td_expr.TdExpr,
+        pattern: str | td_expr.Expr,
+        value: str | td_expr.Expr,
         *,
         literal: bool = False,
         n: int = 1,
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         """
         Replace the first occurence of a pattern with the given string.
 
@@ -785,7 +808,7 @@ class TdExprStringNameSpace:
         └───────────┴───────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.replace(
                 pattern=td_expr.td_translator._unwrap_tdexpr(pattern),
                 value=td_expr.td_translator._unwrap_tdexpr(value),
@@ -794,13 +817,14 @@ class TdExprStringNameSpace:
             )
         )
 
+    @pydoc(categories="string")
     def replace_all(
         self,
-        pattern: str | td_expr.TdExpr,
-        value: str | td_expr.TdExpr,
+        pattern: str | td_expr.Expr,
+        value: str | td_expr.Expr,
         *,
         literal: bool = False,
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         """
         Replace the all occurences of a pattern with the given string.
 
@@ -831,7 +855,7 @@ class TdExprStringNameSpace:
         └───────────┴─────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.replace_all(
                 pattern=td_expr.td_translator._unwrap_tdexpr(pattern),
                 value=td_expr.td_translator._unwrap_tdexpr(value),
@@ -839,7 +863,8 @@ class TdExprStringNameSpace:
             )
         )
 
-    def reverse(self) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def reverse(self) -> td_expr.Expr:
         """
         Reverse the string.
 
@@ -861,13 +886,14 @@ class TdExprStringNameSpace:
         │ null ┆ null    │
         └──────┴─────────┘
         """
-        return to_tdexpr(self._expr.reverse())
+        return _to_tdexpr(self._expr.reverse())
 
+    @pydoc(categories="string")
     def slice(
         self,
-        offset: int | td_expr.IntoTdExprColumn,
-        length: int | td_expr.IntoTdExprColumn | None = None,
-    ) -> td_expr.TdExpr:
+        offset: int | td_expr.IntoExprColumn,
+        length: int | td_expr.IntoExprColumn | None = None,
+    ) -> td_expr.Expr:
         """
         Extract the substring at the given offset for the given length.
 
@@ -894,14 +920,15 @@ class TdExprStringNameSpace:
         └──────┴───────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.slice(
                 offset=td_translator._unwrap_into_tdexpr(offset),
                 length=td_translator._unwrap_into_tdexpr(length),
             )
         )
 
-    def head(self, n: int | td_expr.IntoTdExprColumn) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def head(self, n: int | td_expr.IntoExprColumn) -> td_expr.Expr:
         """
         Extract the start of the string up to the given length.
 
@@ -927,9 +954,12 @@ class TdExprStringNameSpace:
         └──────┴──────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(self._expr.head(n=td_translator._unwrap_into_tdexpr_column(n)))
+        return _to_tdexpr(
+            self._expr.head(n=td_translator._unwrap_into_tdexpr_column(n))
+        )
 
-    def tail(self, n: int | td_expr.IntoTdExprColumn) -> td_expr.TdExpr:
+    @pydoc(categories="string")
+    def tail(self, n: int | td_expr.IntoExprColumn) -> td_expr.Expr:
         """
         Extract the end of the string up to the given length.
 
@@ -955,11 +985,14 @@ class TdExprStringNameSpace:
         └──────┴──────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(self._expr.tail(n=td_translator._unwrap_into_tdexpr_column(n)))
+        return _to_tdexpr(
+            self._expr.tail(n=td_translator._unwrap_into_tdexpr_column(n))
+        )
 
+    @pydoc(categories="type_casting")
     def to_integer(
-        self, *, base: int | td_expr.IntoTdExprColumn = 10, strict: bool = True
-    ) -> td_expr.TdExpr:
+        self, *, base: int | td_expr.IntoExprColumn = 10, strict: bool = True
+    ) -> td_expr.Expr:
         """
         Covert a string to integer.
 
@@ -988,15 +1021,16 @@ class TdExprStringNameSpace:
         └──────┴────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.to_integer(
                 base=td_translator._unwrap_into_tdexpr_column(base), strict=strict
             )
         )
 
+    @pydoc(categories="string")
     def contains_any(
-        self, patterns: td_expr.IntoTdExpr, *, ascii_case_insensitive: bool = False
-    ) -> td_expr.TdExpr:
+        self, patterns: td_expr.IntoExpr, *, ascii_case_insensitive: bool = False
+    ) -> td_expr.Expr:
         """
         Evaluate if the string contains any of the given patterns.
 
@@ -1025,20 +1059,21 @@ class TdExprStringNameSpace:
         └──────┴──────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.contains_any(
                 patterns=td_translator._unwrap_into_tdexpr(patterns),
                 ascii_case_insensitive=ascii_case_insensitive,
             )
         )
 
+    @pydoc(categories="string")
     def replace_many(
         self,
-        patterns: td_expr.IntoTdExpr | Mapping[str, str],
-        replace_with: td_expr.IntoTdExpr | NoDefault = no_default,
+        patterns: td_expr.IntoExpr | Mapping[str, str],
+        replace_with: td_expr.IntoExpr | NoDefault = no_default,
         *,
         ascii_case_insensitive: bool = False,
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         """
         Replace the all occurences of any the given patterns with the given string.
 
@@ -1069,7 +1104,7 @@ class TdExprStringNameSpace:
         └──────┴──────────────┘
         """
         # noinspection PyProtectedMember
-        return to_tdexpr(
+        return _to_tdexpr(
             self._expr.replace_many(
                 patterns=td_translator._unwrap_into_tdexpr(patterns),
                 replace_with=td_translator._unwrap_into_tdexpr(replace_with),

--- a/client/td-sdk/tabsdata/tableframe/functions/col.py
+++ b/client/td-sdk/tabsdata/tableframe/functions/col.py
@@ -10,8 +10,10 @@ from collections.abc import Iterable
 import polars as pl
 
 # noinspection PyProtectedMember
-from polars._typing import PolarsDataType, PythonDataType
+from polars._typing import PythonDataType
 
+# noinspection PyProtectedMember
+import tabsdata.tableframe._typing as td_typing
 import tabsdata.tableframe.expr.expr as td_expr
 
 # noinspection PyProtectedMember
@@ -25,13 +27,13 @@ def _new_col(
     check: bool,
     name: (
         str
-        | PolarsDataType
+        | td_typing.DataType
         | PythonDataType
         | Iterable[str]
-        | Iterable[PolarsDataType | PythonDataType]
+        | Iterable[td_typing.DataType | PythonDataType]
     ),
-    *more_names: str | PolarsDataType | PythonDataType,
-) -> td_expr.TdExpr:
+    *more_names: str | td_typing.DataType | PythonDataType,
+) -> td_expr.Expr:
     if check:
         td_common.check_columns(name, *more_names)
     return _create_col(name, *more_names)
@@ -40,17 +42,17 @@ def _new_col(
 def _create_col(
     name: (
         str
-        | PolarsDataType
+        | td_typing.TdDataType
         | PythonDataType
         | Iterable[str]
-        | Iterable[PolarsDataType | PythonDataType]
+        | Iterable[td_typing.TdDataType | PythonDataType]
     ),
-    *more_names: str | PolarsDataType | PythonDataType,
-) -> td_expr.TdExpr:
-    return td_expr.TdExpr(pl.col(name, *more_names))
+    *more_names: str | td_typing.TdDataType | PythonDataType,
+) -> td_expr.Expr:
+    return td_expr.Expr(pl.col(name, *more_names))
 
 
-class TdCol:
+class Col:
     """
     This class is used to create TableFrame column expressions.
 
@@ -76,13 +78,13 @@ class TdCol:
         self,
         name: (
             str
-            | PolarsDataType
+            | td_typing.TdDataType
             | PythonDataType
             | Iterable[str]
-            | Iterable[PolarsDataType | PythonDataType]
+            | Iterable[td_typing.TdDataType | PythonDataType]
         ),
-        *more_names: str | PolarsDataType | PythonDataType,
-    ) -> td_expr.TdExpr:
+        *more_names: str | td_typing.TdDataType | PythonDataType,
+    ) -> td_expr.Expr:
         """
         Create a TableFrame column expression.
 
@@ -103,7 +105,7 @@ class TdCol:
         """
         return _new_col(True, name, *more_names)
 
-    def __getattr__(self, name: str) -> td_expr.TdExpr:
+    def __getattr__(self, name: str) -> td_expr.Expr:
         """
         Constructs a column expression using attribute syntax.
 
@@ -124,4 +126,4 @@ class TdCol:
         return _new_col(True, name)
 
 
-tdcol: TdCol = TdCol()
+col: Col = Col()

--- a/client/td-sdk/tabsdata/tableframe/functions/datetime.py
+++ b/client/td-sdk/tabsdata/tableframe/functions/datetime.py
@@ -3,29 +3,32 @@ from __future__ import annotations
 import datetime as dt
 from typing import Iterable
 
+import polars.expr.datetime as pl_datetime
+
 # noinspection PyProtectedMember
 from polars._typing import Ambiguous, EpochTimeUnit, NonExistent, Roll, TimeUnit
-from polars.expr.datetime import ExprDateTimeNameSpace
 
 import tabsdata.tableframe.expr.expr as td_expr
 
 # noinspection PyProtectedMember
 import tabsdata.utils.tableframe._translator as td_translator
+from tabsdata.utils.annotations import pydoc
 
 
-class TdExprDateTimeNameSpace:
-    def __init__(self, expr: ExprDateTimeNameSpace) -> None:
+class ExprDateTimeNameSpace:
+    def __init__(self, expr: pl_datetime.ExprDateTimeNameSpace) -> None:
         self._expr = expr
 
+    @pydoc(categories="date")
     def add_business_days(
         self,
-        n: int | td_expr.IntoTdExpr,
+        n: int | td_expr.IntoExpr,
         week_mask: Iterable[bool] = (True, True, True, True, True, False, False),
         holidays: Iterable[dt.date] = (),
         roll: Roll = "raise",
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         # noinspection PyProtectedMember
-        return td_expr.TdExpr(
+        return td_expr.Expr(
             self._expr.add_business_days(
                 n=td_translator._unwrap_into_tdexpr(n),
                 week_mask=week_mask,
@@ -34,26 +37,27 @@ class TdExprDateTimeNameSpace:
             )
         )
 
-    def truncate(self, every: str | dt.timedelta | td_expr.TdExpr) -> td_expr.TdExpr:
+    @pydoc(categories="date")
+    def truncate(self, every: str | dt.timedelta | td_expr.Expr) -> td_expr.Expr:
         # noinspection PyProtectedMember
-        return td_expr.TdExpr(
+        return td_expr.Expr(
             self._expr.truncate(every=td_translator._unwrap_tdexpr(every))
         )
 
     def replace(
         self,
         *,
-        year: int | td_expr.IntoTdExpr | None = None,
-        month: int | td_expr.IntoTdExpr | None = None,
-        day: int | td_expr.IntoTdExpr | None = None,
-        hour: int | td_expr.IntoTdExpr | None = None,
-        minute: int | td_expr.IntoTdExpr | None = None,
-        second: int | td_expr.IntoTdExpr | None = None,
-        microsecond: int | td_expr.IntoTdExpr | None = None,
-        ambiguous: Ambiguous | td_expr.TdExpr = "raise",
-    ) -> td_expr.TdExpr:
+        year: int | td_expr.IntoExpr | None = None,
+        month: int | td_expr.IntoExpr | None = None,
+        day: int | td_expr.IntoExpr | None = None,
+        hour: int | td_expr.IntoExpr | None = None,
+        minute: int | td_expr.IntoExpr | None = None,
+        second: int | td_expr.IntoExpr | None = None,
+        microsecond: int | td_expr.IntoExpr | None = None,
+        ambiguous: Ambiguous | td_expr.Expr = "raise",
+    ) -> td_expr.Expr:
         # noinspection PyProtectedMember
-        return td_expr.TdExpr(
+        return td_expr.Expr(
             self._expr.replace(
                 year=td_translator._unwrap_into_tdexpr(year),
                 month=td_translator._unwrap_into_tdexpr(month),
@@ -66,106 +70,135 @@ class TdExprDateTimeNameSpace:
             )
         )
 
+    @pydoc(categories="date")
     def combine(
-        self, time: dt.time | td_expr.TdExpr, time_unit: TimeUnit = "us"
-    ) -> td_expr.TdExpr:
+        self, time: dt.time | td_expr.Expr, time_unit: TimeUnit = "us"
+    ) -> td_expr.Expr:
         # noinspection PyProtectedMember
-        return td_expr.TdExpr(
+        return td_expr.Expr(
             self._expr.combine(
                 time=td_translator._unwrap_tdexpr(time), time_unit=time_unit
             )
         )
 
-    def to_string(self, fmt: str | None = None) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.to_string(format=fmt))
+    @pydoc(categories="type_casting")
+    def to_string(self, fmt: str | None = None) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.to_string(format=fmt))
 
-    def strftime(self, fmt: str) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.strftime(format=fmt))
+    @pydoc(categories="date")
+    def strftime(self, fmt: str) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.strftime(format=fmt))
 
-    def millennium(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.millennium())
+    @pydoc(categories="date")
+    def millennium(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.millennium())
 
-    def century(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.century())
+    @pydoc(categories="date")
+    def century(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.century())
 
-    def year(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.year())
+    @pydoc(categories="date")
+    def year(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.year())
 
-    def is_leap_year(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.is_leap_year())
+    @pydoc(categories="date")
+    def is_leap_year(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.is_leap_year())
 
-    def iso_year(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.iso_year())
+    @pydoc(categories="date")
+    def iso_year(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.iso_year())
 
-    def quarter(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.quarter())
+    @pydoc(categories="date")
+    def quarter(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.quarter())
 
-    def month(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.month())
+    @pydoc(categories="date")
+    def month(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.month())
 
-    def week(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.week())
+    @pydoc(categories="date")
+    def week(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.week())
 
-    def weekday(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.weekday())
+    @pydoc(categories="date")
+    def weekday(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.weekday())
 
-    def day(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.day())
+    @pydoc(categories="date")
+    def day(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.day())
 
-    def ordinal_day(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.ordinal_day())
+    @pydoc(categories="date")
+    def ordinal_day(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.ordinal_day())
 
-    def time(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.time())
+    @pydoc(categories="date")
+    def time(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.time())
 
-    def date(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.date())
+    @pydoc(categories="date")
+    def date(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.date())
 
-    def datetime(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.datetime())
+    @pydoc(categories="date")
+    def datetime(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.datetime())
 
-    def hour(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.hour())
+    @pydoc(categories="date")
+    def hour(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.hour())
 
-    def minute(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.minute())
+    @pydoc(categories="date")
+    def minute(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.minute())
 
-    def second(self, *, fractional: bool = False) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.second(fractional=fractional))
+    @pydoc(categories="date")
+    def second(self, *, fractional: bool = False) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.second(fractional=fractional))
 
-    def millisecond(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.millisecond())
+    @pydoc(categories="date")
+    def millisecond(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.millisecond())
 
-    def microsecond(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.microsecond())
+    @pydoc(categories="date")
+    def microsecond(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.microsecond())
 
-    def nanosecond(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.nanosecond())
+    @pydoc(categories="date")
+    def nanosecond(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.nanosecond())
 
-    def epoch(self, time_unit: EpochTimeUnit = "us") -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.epoch(time_unit=time_unit))
+    @pydoc(categories="date")
+    def epoch(self, time_unit: EpochTimeUnit = "us") -> td_expr.Expr:
+        return td_expr.Expr(self._expr.epoch(time_unit=time_unit))
 
-    def timestamp(self, time_unit: TimeUnit = "us") -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.timestamp(time_unit=time_unit))
+    @pydoc(categories="date")
+    def timestamp(self, time_unit: TimeUnit = "us") -> td_expr.Expr:
+        return td_expr.Expr(self._expr.timestamp(time_unit=time_unit))
 
-    def with_time_unit(self, time_unit: TimeUnit) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.with_time_unit(time_unit))
+    @pydoc(categories="date")
+    def with_time_unit(self, time_unit: TimeUnit) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.with_time_unit(time_unit))
 
-    def cast_time_unit(self, time_unit: TimeUnit) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.cast_time_unit(time_unit))
+    @pydoc(categories="date")
+    def cast_time_unit(self, time_unit: TimeUnit) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.cast_time_unit(time_unit))
 
-    def convert_time_zone(self, time_zone: str) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.convert_time_zone(time_zone))
+    @pydoc(categories="date")
+    def convert_time_zone(self, time_zone: str) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.convert_time_zone(time_zone))
 
+    @pydoc(categories="date")
     def replace_time_zone(
         self,
         time_zone: str | None,
         *,
-        ambiguous: Ambiguous | td_expr.TdExpr = "raise",
+        ambiguous: Ambiguous | td_expr.Expr = "raise",
         non_existent: NonExistent = "raise",
-    ) -> td_expr.TdExpr:
+    ) -> td_expr.Expr:
         # noinspection PyProtectedMember
-        return td_expr.TdExpr(
+        return td_expr.Expr(
             self._expr.replace_time_zone(
                 time_zone=time_zone,
                 ambiguous=td_translator._unwrap_tdexpr(ambiguous),
@@ -173,41 +206,53 @@ class TdExprDateTimeNameSpace:
             )
         )
 
-    def total_days(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.total_days())
+    @pydoc(categories="date")
+    def total_days(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.total_days())
 
-    def total_hours(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.total_hours())
+    @pydoc(categories="date")
+    def total_hours(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.total_hours())
 
-    def total_minutes(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.total_minutes())
+    @pydoc(categories="date")
+    def total_minutes(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.total_minutes())
 
-    def total_seconds(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.total_seconds())
+    @pydoc(categories="date")
+    def total_seconds(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.total_seconds())
 
-    def total_milliseconds(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.total_milliseconds())
+    @pydoc(categories="date")
+    def total_milliseconds(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.total_milliseconds())
 
-    def total_microseconds(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.total_microseconds())
+    @pydoc(categories="date")
+    def total_microseconds(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.total_microseconds())
 
-    def total_nanoseconds(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.total_nanoseconds())
+    @pydoc(categories="date")
+    def total_nanoseconds(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.total_nanoseconds())
 
-    def offset_by(self, by: str | td_expr.TdExpr) -> td_expr.TdExpr:
+    @pydoc(categories="date")
+    def offset_by(self, by: str | td_expr.Expr) -> td_expr.Expr:
         # noinspection PyProtectedMember
-        return td_expr.TdExpr(
+        return td_expr.Expr(
             self._expr.offset_by(by=td_translator._unwrap_into_tdexpr(by))
         )
 
-    def month_start(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.month_start())
+    @pydoc(categories="date")
+    def month_start(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.month_start())
 
-    def month_end(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.month_end())
+    @pydoc(categories="date")
+    def month_end(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.month_end())
 
-    def base_utc_offset(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.base_utc_offset())
+    @pydoc(categories="date")
+    def base_utc_offset(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.base_utc_offset())
 
-    def dst_offset(self) -> td_expr.TdExpr:
-        return td_expr.TdExpr(self._expr.dst_offset())
+    @pydoc(categories="date")
+    def dst_offset(self) -> td_expr.Expr:
+        return td_expr.Expr(self._expr.dst_offset())

--- a/client/td-sdk/tabsdata/tableframe/functions/eager.py
+++ b/client/td-sdk/tabsdata/tableframe/functions/eager.py
@@ -9,15 +9,17 @@ from typing import Iterable
 import polars as pl
 
 # noinspection PyProtectedMember
-from polars._typing import PolarsType
+import polars._typing as pl_typing
 
 import tabsdata.tableframe.expr.expr as td_expr
 import tabsdata.tableframe.lazyframe.frame as td_frame
+from tabsdata.utils.annotations import pydoc
 
 
+@pydoc(categories="union")
 def concat(
-    items: Iterable[td_frame.TdPolarsType],
-) -> td_frame.TdPolarsType:
+    items: Iterable[td_frame.TdType],
+) -> td_frame.TdType:
     """
     Combine multiple TableFrames by stacking their rows.
 
@@ -63,7 +65,7 @@ def concat(
     │ y    ┆ 20   │
     └──────┴──────┘
     """
-    unwrapped_items = (_unwrap_tdpolars_type(item) for item in items)
+    unwrapped_items = (_unwrap_td_ype(item) for item in items)
     polars_type = pl.concat(
         unwrapped_items,
         how="vertical",
@@ -75,26 +77,26 @@ def concat(
 
 
 def _wrap_polars_type(
-    obj: PolarsType,
-) -> td_frame.TdPolarsType:
+    obj: pl_typing.PolarsType,
+) -> td_frame.TdType:
     if isinstance(obj, pl.LazyFrame):
         # noinspection PyProtectedMember
-        return td_frame.TdLazyFrame.__build__(obj)
+        return td_frame.LazyFrame.__build__(obj)
     elif isinstance(obj, pl.Expr):
         # noinspection PyProtectedMember
-        return td_expr.TdExpr(obj)
+        return td_expr.Expr(obj)
     else:
         return obj
 
 
 # noinspection PyTypeChecker
-def _unwrap_tdpolars_type(
-    obj: td_frame.TdPolarsType,
-) -> PolarsType:
-    if isinstance(obj, td_frame.TdLazyFrame):
+def _unwrap_td_ype(
+    obj: td_frame.TdType,
+) -> pl_typing.PolarsType:
+    if isinstance(obj, td_frame.LazyFrame):
         # noinspection PyProtectedMember
         return obj._lf
-    elif isinstance(obj, td_expr.TdExpr):
+    elif isinstance(obj, td_expr.Expr):
         # noinspection PyProtectedMember
         return obj._expr
     else:

--- a/client/td-sdk/tabsdata/tableframe/functions/lit.py
+++ b/client/td-sdk/tabsdata/tableframe/functions/lit.py
@@ -9,14 +9,15 @@ from typing import Any
 import polars as pl
 
 # noinspection PyProtectedMember
-from polars._typing import PolarsDataType
-
+import tabsdata.tableframe._typing as td_typing
 import tabsdata.tableframe.expr.expr as td_expr
+from tabsdata.utils.annotations import pydoc
 
 
+@pydoc(categories="generation")
 def lit(
-    value: Any, dtype: PolarsDataType | None = None, *, allow_object: bool = False
-) -> td_expr.TdExpr:
+    value: Any, dtype: td_typing.TdDataType | None = None, *, allow_object: bool = False
+) -> td_expr.Expr:
     """
     Expression for the given literal value.
 
@@ -44,4 +45,4 @@ def lit(
     │ Hi   ┆ null │
     └──────┴──────┘
     """
-    return td_expr.TdExpr(pl.lit(value, dtype, allow_object=allow_object))
+    return td_expr.Expr(pl.lit(value, dtype, allow_object=allow_object))

--- a/client/td-sdk/tabsdata/tableframe/lazyframe/group_by.py
+++ b/client/td-sdk/tabsdata/tableframe/lazyframe/group_by.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 import polars as pl
-from polars.lazyframe.group_by import LazyGroupBy
+import polars.lazyframe.group_by as pl_group_by
 
 import tabsdata.tableframe.expr.expr as td_expr
 import tabsdata.tableframe.lazyframe.frame as td_frame
@@ -21,13 +21,14 @@ import tabsdata.utils.tableframe._helpers as td_helpers
 # noinspection PyProtectedMember
 import tabsdata.utils.tableframe._translator as td_translator
 from tabsdata.exceptions import ErrorCode, TableFrameError
+from tabsdata.utils.annotations import pydoc
 
 
-class TdLazyGroupBy:
-    def __init__(self, lgb: LazyGroupBy | TdLazyGroupBy) -> None:
-        if isinstance(lgb, LazyGroupBy):
+class LazyGroupBy:
+    def __init__(self, lgb: pl_group_by.LazyGroupBy | LazyGroupBy) -> None:
+        if isinstance(lgb, pl_group_by.LazyGroupBy):
             self._lgb = lgb
-        elif isinstance(lgb, TdLazyGroupBy):
+        elif isinstance(lgb, LazyGroupBy):
             self._lgb = lgb._lgb
         else:
             raise TableFrameError(ErrorCode.TF6, type(lgb))
@@ -38,9 +39,9 @@ class TdLazyGroupBy:
     # ToDo: proper expressions handling.
     def agg(
         self,
-        *aggs: td_expr.IntoTdExpr | Iterable[td_expr.IntoTdExpr],
-        **named_aggs: td_expr.IntoTdExpr,
-    ) -> td_frame.TdLazyFrame:
+        *aggs: td_expr.IntoExpr | Iterable[td_expr.IntoExpr],
+        **named_aggs: td_expr.IntoExpr,
+    ) -> td_frame.LazyFrame:
         """
         Aggregation expressions for the group by column(s).
 
@@ -105,13 +106,13 @@ class TdLazyGroupBy:
 
         expressions = unwrapped_aggs + unwrapped_required_columns + unwrapped_named_aggs
 
-        return td_frame.TdLazyFrame.__build__(
+        return td_frame.LazyFrame.__build__(
             self._lgb.agg(
                 expressions,
             )
         )
 
-    def len(self) -> td_frame.TdLazyFrame:
+    def len(self) -> td_frame.LazyFrame:
         """
         Aggregation operation that counts the rows in the group.
 
@@ -154,12 +155,14 @@ class TdLazyGroupBy:
         │ D    ┆ 1   │
         └──────┴─────┘
         """
-        return td_frame.TdLazyFrame.__build__(self._lgb.len())
+        return td_frame.LazyFrame.__build__(self._lgb.len())
 
-    def count(self) -> td_frame.TdLazyFrame:
-        return td_frame.TdLazyFrame.__build__(self._lgb.count())
+    @pydoc(categories="aggregation")
+    def count(self) -> td_frame.LazyFrame:
+        return td_frame.LazyFrame.__build__(self._lgb.count())
 
-    def max(self) -> td_frame.TdLazyFrame:
+    @pydoc(categories="aggregation")
+    def max(self) -> td_frame.LazyFrame:
         """
         Aggregation operation that computes the maximum value in the group for
         of all the non `group by` columns.
@@ -203,9 +206,10 @@ class TdLazyGroupBy:
         │ F    ┆ 9    ┆ NaN  │
         └──────┴──────┴──────┘
         """
-        return td_frame.TdLazyFrame.__build__(self._lgb.max())
+        return td_frame.LazyFrame.__build__(self._lgb.max())
 
-    def mean(self) -> td_frame.TdLazyFrame:
+    @pydoc(categories="aggregation")
+    def mean(self) -> td_frame.LazyFrame:
         """
         Aggregation operation that computes the mean value in the group for
         of all the non `group by` columns.
@@ -249,9 +253,10 @@ class TdLazyGroupBy:
         │ F    ┆ 9.0      ┆ NaN      │
         └──────┴──────────┴──────────┘
         """
-        return td_frame.TdLazyFrame.__build__(self._lgb.mean())
+        return td_frame.LazyFrame.__build__(self._lgb.mean())
 
-    def median(self) -> td_frame.TdLazyFrame:
+    @pydoc(categories="aggregation")
+    def median(self) -> td_frame.LazyFrame:
         """
         Aggregation operation that computes the median value in the group for
         of all the non `group by` columns.
@@ -295,9 +300,10 @@ class TdLazyGroupBy:
         │ F    ┆ 9.0  ┆ NaN  │
         └──────┴──────┴──────┘
         """
-        return td_frame.TdLazyFrame.__build__(self._lgb.median())
+        return td_frame.LazyFrame.__build__(self._lgb.median())
 
-    def min(self) -> td_frame.TdLazyFrame:
+    @pydoc(categories="aggregation")
+    def min(self) -> td_frame.LazyFrame:
         """
         Aggregation operation that computes the minimum value in the group for
         of all the non `group by` columns.
@@ -341,9 +347,10 @@ class TdLazyGroupBy:
         │ F    ┆ 9    ┆ NaN  │
         └──────┴──────┴──────┘
         """
-        return td_frame.TdLazyFrame.__build__(self._lgb.min())
+        return td_frame.LazyFrame.__build__(self._lgb.min())
 
-    def n_unique(self) -> td_frame.TdLazyFrame:
+    @pydoc(categories="aggregation")
+    def n_unique(self) -> td_frame.LazyFrame:
         """
         Aggregation operation that counts the unique values of the given column
         in the group for of all the non `group by` columns.
@@ -387,9 +394,10 @@ class TdLazyGroupBy:
         │ F    ┆ 1   ┆ 1   │
         └──────┴─────┴─────┘
         """
-        return td_frame.TdLazyFrame.__build__(self._lgb.n_unique())
+        return td_frame.LazyFrame.__build__(self._lgb.n_unique())
 
-    def sum(self) -> td_frame.TdLazyFrame:
+    @pydoc(categories="aggregation")
+    def sum(self) -> td_frame.LazyFrame:
         """
         Aggregation operation that computes the sum for all values in the group for
         of all the non `group by` columns.
@@ -433,4 +441,4 @@ class TdLazyGroupBy:
         │ F    ┆ 9   ┆ NaN  │
         └──────┴─────┴──────┘
         """
-        return td_frame.TdLazyFrame.__build__(self._lgb.sum())
+        return td_frame.LazyFrame.__build__(self._lgb.sum())

--- a/client/td-sdk/tabsdata/tabsdatafunction.py
+++ b/client/td-sdk/tabsdata/tabsdatafunction.py
@@ -3388,14 +3388,14 @@ def _convert_recursively_to_tableframe(arguments: Any):
         return [_convert_recursively_to_tableframe(v) for v in arguments]
     elif isinstance(arguments, tuple):
         return tuple(_convert_recursively_to_tableframe(v) for v in arguments)
-    elif isinstance(arguments, td_frame.TdLazyFrame):
+    elif isinstance(arguments, td_frame.LazyFrame):
         return arguments
     elif isinstance(arguments, pl.DataFrame):
-        return td_frame.TdLazyFrame.__build__(_add_dummy_required_columns(arguments))
+        return td_frame.LazyFrame.__build__(_add_dummy_required_columns(arguments))
     elif isinstance(arguments, pl.LazyFrame):
-        return td_frame.TdLazyFrame.__build__(_add_dummy_required_columns(arguments))
+        return td_frame.LazyFrame.__build__(_add_dummy_required_columns(arguments))
     elif isinstance(arguments, pd.DataFrame):
-        return td_frame.TdLazyFrame.__build__(
+        return td_frame.LazyFrame.__build__(
             _add_dummy_required_columns(pl.DataFrame(arguments))
         )
     return arguments
@@ -3406,7 +3406,7 @@ def _clean_recursively_and_convert_to_datatype(
     datatype: (
         Type[pl.DataFrame]
         | Type[pl.LazyFrame]
-        | Type[td_frame.TdLazyFrame]
+        | Type[td_frame.LazyFrame]
         | Type[pd.DataFrame]
     ),
 ) -> Any:
@@ -3421,7 +3421,7 @@ def _clean_recursively_and_convert_to_datatype(
         return tuple(
             _clean_recursively_and_convert_to_datatype(v, datatype) for v in result
         )
-    elif isinstance(result, td_frame.TdLazyFrame):
+    elif isinstance(result, td_frame.LazyFrame):
         try:
             if datatype == pl.DataFrame:
                 return result._lf.drop(td_helpers.SYSTEM_COLUMNS).collect()
@@ -3459,11 +3459,11 @@ def _recursively_obtain_datatype(
     Type[pl.DataFrame]
     | Type[pd.DataFrame]
     | Type[pl.LazyFrame]
-    | Type[td_frame.TdLazyFrame]
+    | Type[td_frame.LazyFrame]
     | None
 ):
     if isinstance(
-        arguments, (pl.DataFrame, pl.LazyFrame, td_frame.TdLazyFrame, pd.DataFrame)
+        arguments, (pl.DataFrame, pl.LazyFrame, td_frame.LazyFrame, pd.DataFrame)
     ):
         return type(arguments)
     elif not arguments:
@@ -3478,8 +3478,8 @@ def _recursively_obtain_datatype(
         return pl.DataFrame
     elif pl.LazyFrame in types:
         return pl.LazyFrame
-    elif td_frame.TdLazyFrame in types:
-        return td_frame.TdLazyFrame
+    elif td_frame.LazyFrame in types:
+        return td_frame.LazyFrame
     elif pd.DataFrame in types:
         return pd.DataFrame
     else:

--- a/client/td-sdk/tabsdata/utils/annotations.py
+++ b/client/td-sdk/tabsdata/utils/annotations.py
@@ -1,0 +1,70 @@
+#
+#  Copyright 2025 Tabs Data Inc.
+#
+
+#
+#
+
+import inspect
+import logging
+from dataclasses import dataclass
+from functools import wraps
+from typing import Callable, List, Literal, ParamSpec, TypeAlias, TypeVar, Union
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+
+def unstable() -> Callable[[Callable[P, T]], Callable[P, T]]:
+    def decorate(function: Callable[P, T]) -> Callable[P, T]:
+        @wraps(function)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            logger.warning(
+                f"Function '{function.__name__}' is under development, subject to "
+                "change, and deemed unstable."
+            )
+            return function(*args, **kwargs)
+
+        wrapper.__signature__ = inspect.signature(function)
+        return wrapper
+
+    return decorate
+
+
+PydocCategories: TypeAlias = Literal[
+    "aggregation",
+    "attributes",
+    "date",
+    "description",
+    "logic",
+    "numeric",
+    "filters",
+    "generation",
+    "join",
+    "manipulation",
+    "projection",
+    "string",
+    "tableframe",
+    "type_casting",
+    "union",
+]
+
+
+@dataclass
+class PydocMetadata:
+    categories: Union[str, List[str]]
+
+
+def pydoc(categories: Union[PydocCategories, List[PydocCategories]]) -> Callable:
+    def decorator(obj):
+        metadata = PydocMetadata(categories=categories)
+        if isinstance(obj, property):
+            obj = property(obj.fget)
+            obj.fget._pydoc_metadata = metadata
+        else:
+            obj._pydoc_metadata = metadata
+        return obj
+
+    return decorator

--- a/client/td-sdk/tabsdata/utils/tableframe/_common.py
+++ b/client/td-sdk/tabsdata/utils/tableframe/_common.py
@@ -8,8 +8,9 @@ from typing import Any, Callable, Iterable
 
 import polars as pl
 from polars import DataFrame
-from polars._typing import PolarsDataType
 
+# noinspection PyProtectedMember
+import tabsdata.tableframe._typing as td_typing
 import tabsdata.utils.tableframe._constants as td_constants
 import tabsdata.utils.tableframe._helpers as td_helpers
 from tabsdata.exceptions import ErrorCode, TableFrameError
@@ -86,7 +87,10 @@ def add_system_columns(ldf: pl.LazyFrame) -> pl.LazyFrame:
 
 
 def add_system_column(
-    column: str, dtype: PolarsDataType, generator: Callable[[], Any], batch: DataFrame
+    column: str,
+    dtype: td_typing.TdDataType,
+    generator: Callable[[], Any],
+    batch: DataFrame,
 ) -> DataFrame:
     return batch.with_columns(
         pl.first()
@@ -99,7 +103,7 @@ def add_system_column(
 
 
 def generate_system_column(
-    column: str, dtype: PolarsDataType, generator: Callable[[], Any], size: int
+    column: str, dtype: td_typing.TdDataType, generator: Callable[[], Any], size: int
 ):
     values = []
     for i in range(size):

--- a/client/td-sdk/tabsdata/utils/tableframe/_translator.py
+++ b/client/td-sdk/tabsdata/utils/tableframe/_translator.py
@@ -24,35 +24,33 @@ def _is_instance_of_union(obj, tp):
     return False
 
 
-def _wrap_polars_frame(f: pl.LazyFrame | pl.DataFrame) -> td_frame.TdLazyFrame:
+def _wrap_polars_frame(f: pl.LazyFrame | pl.DataFrame) -> td_frame.LazyFrame:
     if isinstance(f, pl.LazyFrame):
         # noinspection PyProtectedMember
-        return td_frame.TdLazyFrame._from_lazy(f)
+        return td_frame.LazyFrame._from_lazy(f)
     elif isinstance(f, pl.DataFrame):
         # noinspection PyProtectedMember
-        return td_frame.TdLazyFrame._from_lazy(f.lazy())
+        return td_frame.LazyFrame._from_lazy(f.lazy())
     else:
         raise TableFrameError(ErrorCode.TF7, type(f))
 
 
-def _unwrap_table_frame(tf: td_frame.TdLazyFrame):
+def _unwrap_table_frame(tf: td_frame.LazyFrame):
     # noinspection PyProtectedMember
-    return td_common.drop_system_columns(td_frame.TdLazyFrame._to_lazy(tf))
+    return td_common.drop_system_columns(td_frame.LazyFrame._to_lazy(tf))
 
 
 # noinspection PyProtectedMember
 def _unwrap_tdexpr(expr: Any) -> pl.Expr | List[pl.Expr] | Any:
-    if isinstance(expr, td_expr.TdExpr):
+    if isinstance(expr, td_expr.Expr):
         return expr._expr
     elif isinstance(expr, dict):
         return {
-            key: value._expr if isinstance(value, td_expr.TdExpr) else value
+            key: value._expr if isinstance(value, td_expr.Expr) else value
             for key, value in expr.items()
         }
     elif isinstance(expr, Collection) and not isinstance(expr, (str, bytes)):
-        return [
-            item._expr if isinstance(item, td_expr.TdExpr) else item for item in expr
-        ]
+        return [item._expr if isinstance(item, td_expr.Expr) else item for item in expr]
     else:
         return expr
 
@@ -60,16 +58,14 @@ def _unwrap_tdexpr(expr: Any) -> pl.Expr | List[pl.Expr] | Any:
 def _unwrap_into_tdexpr_column(
     expr: Any,
 ) -> pl.IntoExprColumn | List[pl.IntoExprColumn] | Any:
-    if isinstance(expr, td_expr.TdExpr):
+    if isinstance(expr, td_expr.Expr):
         # noinspection PyProtectedMember
         return expr._expr
     elif isinstance(expr, dict):
         return {key: _unwrap_into_tdexpr_column(value) for key, value in expr.items()}
     elif isinstance(expr, Collection) and not isinstance(expr, (str, bytes)):
         # noinspection PyProtectedMember
-        return [
-            item._expr if isinstance(item, td_expr.TdExpr) else item for item in expr
-        ]
+        return [item._expr if isinstance(item, td_expr.Expr) else item for item in expr]
     else:
         return expr
 
@@ -77,7 +73,7 @@ def _unwrap_into_tdexpr_column(
 def _unwrap_into_tdexpr(expr: Any) -> pl.IntoExpr | List[pl.IntoExpr] | Any:
     if expr is None:
         return None
-    if _is_instance_of_union(expr, td_expr.IntoTdExprColumn):
+    if _is_instance_of_union(expr, td_expr.IntoExprColumn):
         # noinspection PyProtectedMember
         return _unwrap_into_tdexpr_column(expr)
     elif isinstance(expr, dict):
@@ -89,9 +85,9 @@ def _unwrap_into_tdexpr(expr: Any) -> pl.IntoExpr | List[pl.IntoExpr] | Any:
 
 
 def _unwrap_tdexpr_date_time_name_space(
-    expr: td_datetime.TdExprDateTimeNameSpace,
+    expr: td_datetime.ExprDateTimeNameSpace,
 ) -> pl.ExprDateTimeNameSpace:
-    if isinstance(expr, td_datetime.TdExprDateTimeNameSpace):
+    if isinstance(expr, td_datetime.ExprDateTimeNameSpace):
         # noinspection PyProtectedMember
         return expr._expr
     else:

--- a/client/td-sdk/tests/test_tableframe/functions/test_col.py
+++ b/client/td-sdk/tests/test_tableframe/functions/test_col.py
@@ -11,7 +11,7 @@ import pytest
 
 import tabsdata as td
 from tabsdata.exceptions import ErrorCode, TabsDataException
-from tabsdata.tableframe.expr.expr import TdExpr
+from tabsdata.tableframe.expr.expr import Expr
 
 # noinspection PyProtectedMember
 from tabsdata.utils.tableframe._helpers import system_columns
@@ -37,15 +37,15 @@ def test_reserved_column():
 
 
 def test_common_column():
-    assert isinstance(td.col("my_column"), TdExpr)
-    assert isinstance(td.col("^my_column"), TdExpr)
-    assert isinstance(td.col("$my_column"), TdExpr)
-    assert isinstance(td.col("my_column^"), TdExpr)
-    assert isinstance(td.col("my_column$"), TdExpr)
-    assert isinstance(td.col("$my_column^"), TdExpr)
-    assert isinstance(td.col("*my_column"), TdExpr)
-    assert isinstance(td.col("my*column"), TdExpr)
-    assert isinstance(td.col("*my_column*"), TdExpr)
+    assert isinstance(td.col("my_column"), Expr)
+    assert isinstance(td.col("^my_column"), Expr)
+    assert isinstance(td.col("$my_column"), Expr)
+    assert isinstance(td.col("my_column^"), Expr)
+    assert isinstance(td.col("my_column$"), Expr)
+    assert isinstance(td.col("$my_column^"), Expr)
+    assert isinstance(td.col("*my_column"), Expr)
+    assert isinstance(td.col("my*column"), Expr)
+    assert isinstance(td.col("*my_column*"), Expr)
 
 
 def test_polars_examples():

--- a/client/td-sdk/tests/test_tableframe/lazyframe/test_frame_dunder.py
+++ b/client/td-sdk/tests/test_tableframe/lazyframe/test_frame_dunder.py
@@ -126,11 +126,11 @@ class TestTableFrame(unittest.TestCase):
 
     def test_repr(self):
         string = self.table_frame.__repr__()
-        self.assertTrue(string.startswith("<TdLazyFrame at"))
+        self.assertTrue(string.startswith("<TableFrame at"))
 
     def test_repr_function(self):
         string = repr(self.table_frame)
-        self.assertTrue(string.startswith("<TdLazyFrame at"))
+        self.assertTrue(string.startswith("<TableFrame at"))
 
     # ToDo
     def test_limit(self):

--- a/client/td-sdk/tests/test_tableframe/lazyframe/test_frame_instantation.py
+++ b/client/td-sdk/tests/test_tableframe/lazyframe/test_frame_instantation.py
@@ -9,7 +9,7 @@ import pytest
 
 import tabsdata as td
 from tabsdata.exceptions import ErrorCode, TabsDataException
-from tabsdata.tableframe.lazyframe.frame import TdLazyFrame
+from tabsdata.tableframe.lazyframe.frame import LazyFrame
 
 # noinspection PyProtectedMember
 from tabsdata.utils.tableframe._helpers import REQUIRED_COLUMNS
@@ -42,7 +42,7 @@ def test_init_with_dataframe_with_required_columns():
 def test_init_with_lazyframe_with_required_columns():
     data = {col: [1, 2, 3] for col in REQUIRED_COLUMNS}
     d = pl.DataFrame(data).to_dict(as_series=False)
-    tdf = TdLazyFrame.__build__(d)
+    tdf = LazyFrame.__build__(d)
     assert isinstance(tdf, td.TableFrame)
 
 

--- a/client/td-sdk/tests/test_tableframe/utils/test_common.py
+++ b/client/td-sdk/tests/test_tableframe/utils/test_common.py
@@ -6,7 +6,7 @@ import logging
 
 import polars as pl
 
-from tabsdata.tableframe.lazyframe.frame import TdLazyFrame
+from tabsdata.tableframe.lazyframe.frame import LazyFrame
 
 # noinspection PyProtectedMember
 from tabsdata.utils.tableframe._common import add_system_columns, drop_system_columns
@@ -73,19 +73,19 @@ def test_wrap_and_unwrap_lazy_frame():
 
 
 def test_table_frame_from_none():
-    _ = TdLazyFrame(None)
+    _ = LazyFrame(None)
 
 
 def test_table_frame_from_void():
-    _ = TdLazyFrame()
+    _ = LazyFrame()
 
 
 def test_table_frame_from_empty():
-    _ = TdLazyFrame.empty()
+    _ = LazyFrame.empty()
 
 
 def test_table_frame_from_dictionary():
-    _ = TdLazyFrame(
+    _ = LazyFrame(
         {
             "letters": ["a", "b", "c"],
             "numbers": [1, 2, 3],

--- a/devutils/development/python/pydoc.py
+++ b/devutils/development/python/pydoc.py
@@ -1,0 +1,94 @@
+#
+#  Copyright 2025 Tabs Data Inc.
+#
+
+import ast
+import csv
+import os
+from os.path import join
+
+
+def format_module_path(path, root):
+    module = os.path.relpath(path, root).replace(os.sep, ".")
+    return module[:-3] if module.endswith(".py") else module
+
+
+def extract_categories(decorator):
+    if not isinstance(decorator, ast.Call):
+        return None
+
+    func = decorator.func
+    if not (
+        (isinstance(func, ast.Name) and func.id == "pydoc")
+        or (isinstance(func, ast.Attribute) and func.attr == "pydoc")
+    ):
+        return None
+    for kw in decorator.keywords:
+        if kw.arg == "categories":
+            if isinstance(kw.value, ast.Constant):
+                return kw.value.value
+            elif isinstance(kw.value, ast.List):
+                return [
+                    el.value for el in kw.value.elts if isinstance(el, ast.Constant)
+                ]
+    return None
+
+
+def process_module(path, root):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read(), filename=path)
+    except (SyntaxError, UnicodeDecodeError) as error:
+        print(f"Skipping {path} due to parsing error: {error}")
+        return []
+    report = []
+    module_path = format_module_path(path, root)
+    current_class = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            current_class = node.name
+        elif isinstance(node, ast.FunctionDef):
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Call):
+                    categories = extract_categories(decorator)
+                    if categories is not None:
+                        report.append(
+                            (
+                                categories,
+                                (
+                                    f"{current_class}.{node.name}"
+                                    if current_class
+                                    else node.name
+                                ),
+                                module_path,
+                            )
+                        )
+
+    return report
+
+
+def find_pydoc_categories(root, output):
+    report = []
+    for folder, _, files in os.walk(root):
+        for file in sorted(files):
+            if file.endswith(".py"):
+                report.extend(process_module(join(folder, file), root))
+    report.sort(key=lambda x: (x[0], str(x[1]), str(x[2])))
+    with open(output, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["categories", "function", "module"])
+        writer.writerows(report)
+    print(f"CSV file saved @ '{output}'")
+
+
+def main():
+    location = os.path.dirname(os.path.abspath(__file__))
+    target = join(location, "..", "..", "..", "target", "pydoc")
+    os.makedirs(target, exist_ok=True)
+    root = join(location, "..", "..", "..", "client", "td-sdk")
+    output = join(target, "categories.csv")
+    find_pydoc_categories(root, output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Renamed all Td* entitites to use the exact corresponding name in Polars.
- Wrapped PolarsDataType arounf TdDataTpe (note: only entities from polars having polars string in their name will hev it replaced by td.
- Created decorators @unstbale (to makrk prerelease features) & @pydoc (to automate API documentation generation).
- Created an utility to generate a report of functions with @pydoc decorator.
